### PR TITLE
Adds docker container to quay.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM levim/vcf2maf:1.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,5 @@
 docker.enabled = true
-process.container = 'levim/vcf2maf:1.0'
+process.container = 'quay.io/lifebitai/vcf2maf:latest'
 
 params {
   somatic_vcf = false


### PR DESCRIPTION
## Overview

This PR uploads previously used docker container to quay.io repo.

## Purpose

To solve "reached max pulls" error from docker, because on docker you can pull only 50 times (a day?) and GEL reached it and reported as an issue. On quay.io there is no such a limit, there will be no issue.

## Changes

- adds docker file to current repo that points to original container
- switches container used by the pipeline to the quay.io one

## Notes
I did not add a proper Dockerfile with all installation instructions because it is impossible to rebuild the container at this stage. 
Here is the previously used container's dockerfile: [Dockerfile_vcf2maf](https://github.com/levvim/gdocker/blob/master/vcf2maf/Dockerfile_vcf2maf)
It adds some vep data that is not available alongside the container, hence reproduction of container is impossible at this stage.
Here is the original dockerfile that previous dockerfile adds data on top of: https://github.com/thehyve/vcf2maf

## To test:
To run the pipeline test locally do:
(will need to pull a 15 Gb container, but the test run itself takes 5 seconds)
```
NXF_VER=20.01.0 nextflow run https://github.com/lifebit-ai/vcf2maf-nf \
    -r 34ef3bd6c777d856e9f686e328fa2c863e55a921 \
    --somatic_vcf s3://lifebit-featured-datasets/pipelines/vcf2maf-data/TUMOR_vs_NORMAL.vcf \
    --genome GRCh37
```
![image](https://user-images.githubusercontent.com/64809705/126659203-af215e0e-e5cc-4a82-a21d-55afb7a1b807.png)
